### PR TITLE
Pipeline template for capella addons

### DIFF
--- a/vars/capellaAddon.groovy
+++ b/vars/capellaAddon.groovy
@@ -33,7 +33,7 @@ def call(body) {
 
 	tools {
 	    maven "apache-maven-latest"
-	    jdk "oracle-jdk8-latest"
+	    jdk "openjdk-jdk14-latest"
 	}
 
 	stages {

--- a/vars/capellaAddon.groovy
+++ b/vars/capellaAddon.groovy
@@ -68,7 +68,9 @@ def call(body) {
 
 	    stage ('Build') {
 		steps {
-		    sh "mvn --batch-mode -DpackagedSiteName=\"${pipelineParams.name}\" -f \"${pipelineParams.name}/pom.xml\" clean verify"
+		    wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+			sh "mvn --batch-mode -DpackagedSiteName=\"${pipelineParams.name}\" -f \"${pipelineParams.name}/pom.xml\" clean verify"
+		    }
 		}
 	    }
 

--- a/vars/capellaAddon.groovy
+++ b/vars/capellaAddon.groovy
@@ -1,0 +1,79 @@
+def call(body) {
+
+    // Jenkinsfile:
+    // capellaAddon {
+    //   url = "git repo url"  // where the git clone comes from
+    //   name = "addon-name"   // name will be used for:
+    //                              * download folder name: download.eclipse.org/capella/addons/<name>/
+    //                              * dropins and site zip name
+    //
+    //   (optional) targetPlatform = <path-to-tp-pom>, relative to the project root directory
+    //   (optional) versionFolder = <folder-name>. By default, artifacts go to <name>/updates/nightly/<branch>
+    //                               but we want to avoid using 'master' as a folder name, so in your master branch
+    //                               you can e.g. set this to 'v1.5.x' to copy artifacts to
+    //                               <name>/updates/nightly/v1.5.x/.
+    // }.
+
+    def pipelineParams= [targetPlatform: 'releng/capella-releng-parent/tp/capella-default-addon-target/pom.xml',
+			 versionFolder: env.BRANCH_NAME
+    ]
+
+
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = pipelineParams
+    body()
+
+    pipeline {
+
+	options { skipDefaultCheckout() }
+
+	agent {
+	    label "migration"
+	}
+
+	tools {
+	    maven "apache-maven-latest"
+	    jdk "oracle-jdk8-latest"
+	}
+
+	stages {
+
+	    stage ('Checkout addon code') {
+		steps {
+
+		    checkout([$class: 'GitSCM',
+			      branches: [[name: "*/${env.BRANCH_NAME}"]],
+			      doGenerateSubmoduleConfigurations: false,
+			      extensions: [[$class: 'RelativeTargetDirectory',
+					    relativeTargetDir: pipelineParams.name]],
+			      submoduleCfg: [], userRemoteConfigs: [[url: pipelineParams.url]]])
+		}
+	    }
+
+
+	    stage ('Generate Targetplatform'){
+		steps {
+		    sh "mvn --batch-mode --activate-profiles generate-target -f \"${pipelineParams.name}/${pipelineParams.targetPlatform}\" clean install"
+		}
+	    }
+
+	    stage ('Build') {
+		steps {
+		    sh "mvn --batch-mode -DpackagedSiteName=\"${pipelineParams.name}\" -f \"${pipelineParams.name}/pom.xml\" clean verify"
+		}
+	    }
+
+
+	    stage ('Publish Nightly'){
+		when { !changeRequest() }
+		steps {
+		    dir (pipelineParams.name) {
+			sshagent (['projects-storage.eclipse.org-bot-ssh']) {
+			    sh "../capella-releng-parent/scripts/deployAddonNightly.sh -n \"${pipelineParams.name}\" -b \"${pipelineParams.versionFolder}\""
+			}
+		    }
+		}
+	    }
+	}
+    }
+}

--- a/vars/capellaAddon.groovy
+++ b/vars/capellaAddon.groovy
@@ -45,7 +45,16 @@ def call(body) {
 			      branches: [[name: "*/${env.BRANCH_NAME}"]],
 			      doGenerateSubmoduleConfigurations: false,
 			      extensions: [[$class: 'RelativeTargetDirectory',
-					    relativeTargetDir: pipelineParams.name]],
+					    relativeTargetDir: pipelineParams.name],
+					   [
+				$class: 'SubmoduleOption',
+				disableSubmodules: false,
+				parentCredentials: true,
+				recursiveSubmodules: true,
+				reference: '',
+				trackingSubmodules: true
+			    ]
+			],
 			      submoduleCfg: [], userRemoteConfigs: [[url: pipelineParams.url]]])
 		}
 	    }
@@ -65,11 +74,16 @@ def call(body) {
 
 
 	    stage ('Publish Nightly'){
-		when { !changeRequest() }
+		when {
+		    not {
+			changeRequest()
+		    }
+		}
+
 		steps {
 		    dir (pipelineParams.name) {
 			sshagent (['projects-storage.eclipse.org-bot-ssh']) {
-			    sh "../capella-releng-parent/scripts/deployAddonNightly.sh -n \"${pipelineParams.name}\" -b \"${pipelineParams.versionFolder}\""
+			    sh "releng/capella-releng-parent/scripts/deployAddonNightly.sh -n \"${pipelineParams.name}\" -b \"${pipelineParams.versionFolder}\""
 			}
 		    }
 		}


### PR DESCRIPTION
This makes standard addon Jenkinsfiles very simple:

capellaAddon {
    url = \<my addon git url\>
    name = 'MyAddon'
    targetPlatform = "MyAddon/my/targetplatform/pom.xml"
    versionFolder = 'some-custom-folder'
}

Optional parameters are:
========================
    targetPlatform:
    if not present, the build will use a default addon targetplatform

    versionFolder:
    defaults to the name of the branch being built. can be used
    to redirect master branch artifacts to the upcoming capella version
    (see below)

The 'name' parameter will be used to for 3 things:
==================================================

 dropins zip filename
 update site zip filename
 download path segment for artifacts (see below)

Deployment
==========

It is expected that the build produces a single dropins
zip and a single update site + update site zip. These
zipfiles are located by searching for category.xml.

The artifacts (updatesite, updatesite zip, dropins zip)
are then copied to

download.eclipse.org/capella/addons/\<name\>/zips/nightly/\<versionFolder\>
for update site and dropin zips.

download.eclipse.org/capella/addons/\<name\>/updates/nightly/\<versionFolder\>/\<site-version\>

where \<versionFolder\> defaults to the branch name. On master branches
this should be overwritten in Jenkinsfile, using the capella version
that the master branch currently targets.
